### PR TITLE
Bounce upload progress report events

### DIFF
--- a/src/Concerns/ProcessHooks.php
+++ b/src/Concerns/ProcessHooks.php
@@ -29,7 +29,7 @@ trait ProcessHooks
      */
     private function preCreate(TusHookInput $payload)
     {
-        Log::info("Processing preCreate...", ['payload' => $payload]);
+        Log::info("Processing preCreate...", ['payload' => $payload->__toString()]);
 
         $requestId = $payload->id();
         $token = $payload->input('MetaData.token');
@@ -56,6 +56,10 @@ trait ProcessHooks
         
             $upload = $this->uploads->findByUploadRequestAndToken($requestId, $token);
 
+            if(is_null($upload)){
+                return true;
+            }
+
             if(is_null($upload->tus_id)){
                 // first progress update, we get the id and the first offset information
                 $this->uploads->updateTusIdAndProgress($upload, $payload->tusId(), $payload->input('Offset', 0));
@@ -66,13 +70,16 @@ trait ProcessHooks
                 
                 // subsequent progress events, we update the entry in the database only if
                 if($payload->input('Offset') > $upload->offset && $currentPercent > ($savedPercent + 10)){
+
+                    Log::info("Processing postReceive...", ['payload' => $payload->__toString()]);
+
                     // let's update the status of the upload
                     $this->uploads->updateProgress($upload, $payload->input('Offset'));
                 }
             }
             
         }catch(Exception $ex){
-            
+            Log::error("Processing postReceive error.", ['ex' => $ex]);
         }
 
         return true;
@@ -83,7 +90,7 @@ trait ProcessHooks
      */
     private function postFinish(TusHookInput $payload)
     {
-        Log::info("Processing postFinish...", ['payload' => $payload]);
+        Log::info("Processing postFinish...", ['payload' => $payload->__toString()]);
 
         $requestId = $payload->id();
         $token = $payload->input('MetaData.token');
@@ -91,7 +98,7 @@ trait ProcessHooks
         $upload = $this->uploads->findByUploadRequestAndToken($requestId, $token);
 
         if(is_null($upload)){
-            Log::error("Upload {$requestId}-{$token} not found.");
+            Log::error("Tus post finish, upload {$requestId}-{$token} not found.");
             return false;
         }
 
@@ -109,7 +116,7 @@ trait ProcessHooks
      */
     private function postTerminate(TusHookInput $payload)
     {
-        Log::info("Processing postTerminate...", ['payload' => $payload]);
+        Log::info("Processing postTerminate...", ['payload' => $payload->__toString()]);
 
         $requestId = $payload->id();
         $token = $payload->input('MetaData.token');

--- a/src/Concerns/ProcessHooks.php
+++ b/src/Concerns/ProcessHooks.php
@@ -29,6 +29,8 @@ trait ProcessHooks
      */
     private function preCreate(TusHookInput $payload)
     {
+        Log::info("Processing preCreate...", ['payload' => $payload]);
+
         $requestId = $payload->id();
         $token = $payload->input('MetaData.token');
         
@@ -49,14 +51,28 @@ trait ProcessHooks
     {
         $requestId = $payload->id();
         $token = $payload->input('MetaData.token');
-        
-        $upload = $this->uploads->findByUploadRequestAndToken($requestId, $token);
 
-        // let's update the status of the upload
-        $this->uploads->updateProgress($upload, $payload->input('Offset'));
+        try{
         
-        if(is_null($upload->tus_id)){
-            $this->uploads->updateTusId($upload, $payload->tusId());
+            $upload = $this->uploads->findByUploadRequestAndToken($requestId, $token);
+
+            if(is_null($upload->tus_id)){
+                // first progress update, we get the id and the first offset information
+                $this->uploads->updateTusIdAndProgress($upload, $payload->tusId(), $payload->input('Offset', 0));
+            }
+            else {
+                $currentPercent = ($payload->input('Offset') * 100) / $upload->size;
+                $savedPercent = ($upload->offset * 100) / $upload->size;
+                
+                // subsequent progress events, we update the entry in the database only if
+                if($payload->input('Offset') > $upload->offset && $currentPercent > ($savedPercent + 10)){
+                    // let's update the status of the upload
+                    $this->uploads->updateProgress($upload, $payload->input('Offset'));
+                }
+            }
+            
+        }catch(Exception $ex){
+            
         }
 
         return true;
@@ -67,6 +83,8 @@ trait ProcessHooks
      */
     private function postFinish(TusHookInput $payload)
     {
+        Log::info("Processing postFinish...", ['payload' => $payload]);
+
         $requestId = $payload->id();
         $token = $payload->input('MetaData.token');
         
@@ -91,6 +109,8 @@ trait ProcessHooks
      */
     private function postTerminate(TusHookInput $payload)
     {
+        Log::info("Processing postTerminate...", ['payload' => $payload]);
+
         $requestId = $payload->id();
         $token = $payload->input('MetaData.token');
         

--- a/src/Console/Commands/TusHookProcessingCommand.php
+++ b/src/Console/Commands/TusHookProcessingCommand.php
@@ -60,9 +60,6 @@ class TusHookProcessingCommand extends Command
 
         $payload = TusHookInput::create($payloadString);
 
-        Log::info("Processing $hook...", ['payload' => $payload]);
-
-
         if(!in_array($hook, ['pre-create', 'post-finish', 'post-terminate', 'post-receive'])){
             throw new Exception("Unrecognized hook {$hook}");
         }
@@ -76,8 +73,6 @@ class TusHookProcessingCommand extends Command
         }
 
         $done = $this->{camel_case($hook)}($payload);
-
-        Log::info("$hook processed.", ['payload' => $payload, 'done' => $done]);
 
         return $done ? 0 : 1;
     }

--- a/src/Console/TusHookInput.php
+++ b/src/Console/TusHookInput.php
@@ -138,15 +138,8 @@ class TusHookInput
         return $this->input($property);
     }
 
-    // /**
-    //  * Get the validation rules that apply to the request.
-    //  *
-    //  * @return array
-    //  */
-    // public function rules()
-    // {
-    //     return [
-    //         //
-    //     ];
-    // }
+    public function __toString()
+    {
+        return json_encode($this->data);
+    }
 }

--- a/src/TusUploadRepository.php
+++ b/src/TusUploadRepository.php
@@ -149,8 +149,32 @@ class TusUploadRepository
         }
 
         $upload->forceFill([
-            'tus_id' => $tusId,
+            'tus_id' => $tusId,            
         ])->save();
+
+        return $upload;
+    }
+    
+    /**
+     * Update the TusUpload entry with tusId and offset
+     * 
+     * @param  TusUpload  $upload
+     * @param  string  $tusId The tus generated identifier for the upload
+     * @param  int  $offset The new transferred bytes offset
+     * @return \OneOffTech\TusUpload\TusUpload
+     */
+    public function updateTusIdAndProgress(TusUpload $upload, $tusId, $offset)
+    {
+        if($upload->completed() || $upload->cancelled()){
+            return $upload;
+        }
+
+        $upload->forceFill([
+            'tus_id' => $tusId,
+            'offset' => $offset,
+        ])->save();
+            
+        event(new TusUploadProgress($upload));
 
         return $upload;
     }


### PR DESCRIPTION
Reduce the number of upload progress reports. This will lower the pressure on the database, as all events generates a database write.


The upload progress is saved only after 10% increase of the uploaded file size