### PR TITLE
Add http hooks support

### DIFF
--- a/config/tusupload.php
+++ b/config/tusupload.php
@@ -22,7 +22,7 @@ return [
     |
     */
 
-    'hooks' => env('TUSUPLOAD_HOOKS_DIRECTORY') ?: __DIR__ . '/../hooks',
+    'hooks_path' => env('TUSUPLOAD_HOOKS_DIRECTORY') ?: __DIR__ . '/../hooks',
     
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/Commands/TusServerStartCommand.php
+++ b/src/Console/Commands/TusServerStartCommand.php
@@ -57,7 +57,7 @@ class TusServerStartCommand extends Command
             $noHooks = $this->option('no-hooks');
 
             if($noHooks){
-                config(['tusupload.hooks' => '']);
+                config(['tusupload.hooks_path' => '']);
             }
 
             static::startTusd(function ($type, $buffer) {

--- a/src/Console/SupportsTusd.php
+++ b/src/Console/SupportsTusd.php
@@ -153,7 +153,7 @@ trait SupportsTusd
     protected static function hooksPath()
     {
 
-        $base = config('tusupload.hooks');
+        $base = config('tusupload.hooks_path');
 
         if(empty($base)){
             return null;

--- a/tests/Unit/SupportsTusdTraitTest.php
+++ b/tests/Unit/SupportsTusdTraitTest.php
@@ -95,7 +95,7 @@ class SupportsTusdTraitTest extends AbstractTestCase
         
         // make also the hooks config empty
 
-        $this->app['config']->set('tusupload.hooks', '');
+        $this->app['config']->set('tusupload.hooks_path', '');
         
         $arguments = static::tusdArguments();
 


### PR DESCRIPTION
Closes #26 

This pull request add http based hooks support for tracking tus events and upload status.

- **breaking** `hooks` configuration option has been renamed `hooks_path`