### PR TITLE
Service provider publishes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ You can configure the tus related options via environment variables:
 In alternative, if you prefer, you can publish the configuration file in your Laravel installation.
 
 ```
-php artisan vendor:publish --tag=tusupload-config
+php artisan vendor:publish --provider="OneOffTech\TusUpload\Providers\TusUploadServiceProvider" --tag=config
 ```
 
 ### Starting the Tus server

--- a/src/Providers/TusUploadServiceProvider.php
+++ b/src/Providers/TusUploadServiceProvider.php
@@ -25,7 +25,7 @@ class TusUploadServiceProvider extends ServiceProvider
 
         $this->publishes([
             __DIR__.'/../../config/tusupload.php' => config_path('tusupload.php'),
-        ], 'tusupload-config');
+        ], 'config');
 
         if ($this->app->runningInConsole()) {
             $this->commands([
@@ -49,7 +49,7 @@ class TusUploadServiceProvider extends ServiceProvider
         $this->app->bind(AuthenticationResolverContract::class, AuthenticationResolver::class);
         $this->app->singleton(AuthenticationResolver::class, function($app){
             return new AuthenticationResolver(
-                $app->make(Gate::class), 
+                $app->make(Gate::class),
                 Auth::createUserProvider(config('auth.guards.api.provider')));
         });
     }

--- a/src/Providers/TusUploadServiceProvider.php
+++ b/src/Providers/TusUploadServiceProvider.php
@@ -27,6 +27,10 @@ class TusUploadServiceProvider extends ServiceProvider
             __DIR__.'/../../config/tusupload.php' => config_path('tusupload.php'),
         ], 'config');
 
+        $this->publishes([
+            __DIR__.'/../../database/migrations/' => database_path('migrations'),
+        ], 'migrations');
+
         if ($this->app->runningInConsole()) {
             $this->commands([
                 TusServerStartCommand::class,


### PR DESCRIPTION
First of all thanks for the package!

Since most of my projects are using database UUIDs I've added publishing for migration files which makes editing the `user_id` column far easier.

Also most packages don't use an own config file group for configuration files (`tusupload-config` -> `config`). What do you think of this change?